### PR TITLE
New I/O System

### DIFF
--- a/packs/BP/scripts/conduit.ts
+++ b/packs/BP/scripts/conduit.ts
@@ -1,16 +1,11 @@
 import { BlockCustomComponent, world } from "@minecraft/server";
 import { MachineNetwork } from "./network";
-import { getBlockIoCategories } from "@/public_api/src";
 
 export const conduitComponent: BlockCustomComponent = {
   onPlace(e) {
     if (e.block.typeId === e.previousBlock.type.id) return;
 
-    const ioCategories = getBlockIoCategories(e.block);
-    MachineNetwork.updateAdjacent(
-      e.block,
-      ioCategories === "any" ? undefined : ioCategories,
-    );
+    MachineNetwork.updateAdjacent(e.block);
   },
 };
 

--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -17,8 +17,10 @@ import {
 import { InternalNetworkLinkNode } from "./network_links/network_link_internal";
 import {
   getBlockNetworkConnectionType,
+  getMachineIo,
   NetworkConnectionType,
   NetworkStorageTypeData,
+  RegisteredStorageType,
 } from "@/public_api/src";
 import { InternalRegisteredMachine } from "./machine_registry";
 
@@ -38,7 +40,7 @@ let totalNetworkCount = 0; // used to create a unique id
 const networks = new Map<number, MachineNetwork>();
 
 /**
- * A network of machines with a certain I/O category.
+ * A network of machines with a certain I/O type.
  */
 export class MachineNetwork extends DestroyableObject {
   private sendJobRunning = false;
@@ -52,9 +54,9 @@ export class MachineNetwork extends DestroyableObject {
 
   constructor(
     /**
-     * The I/O category of this network.
+     * The I/O type of this network.
      */
-    readonly category: string,
+    readonly ioType: RegisteredStorageType,
     /**
      * This network's dimension.
      */
@@ -383,7 +385,7 @@ export class MachineNetwork extends DestroyableObject {
    */
   isPartOfNetwork(
     location: DimensionLocation,
-    type: NetworkConnectionType,
+    connectionType: NetworkConnectionType,
   ): boolean {
     this.ensureValidity();
 
@@ -392,11 +394,11 @@ export class MachineNetwork extends DestroyableObject {
     const condition = (other: Block): boolean =>
       Vector3Utils.equals(location, other.location);
 
-    if (type === NetworkConnectionType.Conduit) {
+    if (connectionType === NetworkConnectionType.Conduit) {
       return this.connections.conduits.some(condition);
     }
 
-    if (type === NetworkConnectionType.NetworkLink) {
+    if (connectionType === NetworkConnectionType.NetworkLink) {
       return this.connections.networkLinks.some(condition);
     }
 
@@ -420,7 +422,7 @@ export class MachineNetwork extends DestroyableObject {
 
   private static discoverConnections(
     origin: Block,
-    category: string,
+    ioType: RegisteredStorageType,
   ): NetworkConnections {
     const connections: NetworkConnections = {
       conduits: [],
@@ -481,12 +483,14 @@ export class MachineNetwork extends DestroyableObject {
       );
       if (isHandled) return;
 
-      const isSameCategory = nextBlock.hasTag(
-        `fluffyalien_energisticscore:io.${category}`,
-      );
-      const allowsAny = nextBlock.hasTag("fluffyalien_energisticscore:io._any");
+      const io = getMachineIo(nextBlock);
 
-      if (isSameCategory || allowsAny) handleBlock(nextBlock);
+      const allowsType =
+        io === "any" ||
+        io.types.includes(ioType.id) ||
+        io.categories.includes(ioType.category);
+
+      if (allowsType) handleBlock(nextBlock);
     }
 
     handleBlock(origin);
@@ -507,13 +511,16 @@ export class MachineNetwork extends DestroyableObject {
   /**
    * Establish a new network at `location`.
    */
-  static establish(category: string, block: Block): MachineNetwork | undefined {
-    const connections = MachineNetwork.discoverConnections(block, category);
+  static establish(
+    ioType: RegisteredStorageType,
+    block: Block,
+  ): MachineNetwork | undefined {
+    const connections = MachineNetwork.discoverConnections(block, ioType);
     if (!connections.machines.length) {
       return;
     }
 
-    return new MachineNetwork(category, block.dimension, connections);
+    return new MachineNetwork(ioType, block.dimension, connections);
   }
 
   static getFromId(id: number): MachineNetwork | undefined {
@@ -522,17 +529,17 @@ export class MachineNetwork extends DestroyableObject {
 
   /**
    * Get the {@link MachineNetwork} that contains a machine that matches the arguments.
-   * @param category the category of the network.
+   * @param type the I/O type of the network.
    */
   static getWith(
-    category: string,
+    ioType: RegisteredStorageType,
     location: DimensionLocation,
-    type: NetworkConnectionType,
+    connectionType: NetworkConnectionType,
   ): MachineNetwork | undefined {
     return [...networks.values()].find(
       (network) =>
-        network.category === category &&
-        network.isPartOfNetwork(location, type),
+        network.ioType.id === ioType.id &&
+        network.isPartOfNetwork(location, connectionType),
     );
   }
 
@@ -540,12 +547,12 @@ export class MachineNetwork extends DestroyableObject {
    * Get the {@link MachineNetwork} that contains a block.
    */
   static getWithBlock(
-    category: string,
+    ioType: RegisteredStorageType,
     block: Block,
   ): MachineNetwork | undefined {
     const type = getBlockNetworkConnectionType(block);
     if (!type) return;
-    return MachineNetwork.getWith(category, block, type);
+    return MachineNetwork.getWith(ioType, block, type);
   }
 
   /**
@@ -575,35 +582,24 @@ export class MachineNetwork extends DestroyableObject {
    * @see {@link MachineNetwork.getWithBlock}, {@link MachineNetwork.establish}
    */
   static getOrEstablish(
-    category: string,
+    ioType: RegisteredStorageType,
     block: Block,
   ): MachineNetwork | undefined {
     return (
-      MachineNetwork.getWithBlock(category, block) ??
-      MachineNetwork.establish(category, block)
+      MachineNetwork.getWithBlock(ioType, block) ??
+      MachineNetwork.establish(ioType, block)
     );
   }
 
   /**
    * Update all {@link MachineNetwork}s adjacent to a location.
-   * @param categories Only update networks of these I/O categories. If this is `undefined` then all adjacent networks will be updated.
    */
-  static updateAdjacent(
-    location: DimensionLocation,
-    categories?: string[],
-  ): void {
+  static updateAdjacent(location: DimensionLocation): void {
     for (const directionVector of DIRECTION_VECTORS) {
       const blockInDirection = location.dimension.getBlock(
         Vector3Utils.add(location, directionVector),
       );
       if (!blockInDirection) {
-        continue;
-      }
-
-      if (categories) {
-        for (const category of categories) {
-          MachineNetwork.getWithBlock(category, blockInDirection)?.destroy();
-        }
         continue;
       }
 

--- a/packs/BP/scripts/network_links/network_link_component.ts
+++ b/packs/BP/scripts/network_links/network_link_component.ts
@@ -1,5 +1,4 @@
 import { BlockCustomComponent } from "@minecraft/server";
-import { getBlockIoCategories } from "@/public_api/src";
 import { MachineNetwork } from "../network";
 import {
   deserializeDimensionLocation,
@@ -10,11 +9,7 @@ import { raise } from "../utils/log";
 
 export const networkLinkComponent: BlockCustomComponent = {
   onPlace(ev) {
-    const ioCategories = getBlockIoCategories(ev.block);
-    MachineNetwork.updateAdjacent(
-      ev.block,
-      ioCategories === "any" ? undefined : ioCategories,
-    );
+    MachineNetwork.updateAdjacent(ev.block);
   },
 
   onPlayerDestroy(ev) {

--- a/public_api/src/io.ts
+++ b/public_api/src/io.ts
@@ -1,16 +1,27 @@
 import { Block } from "@minecraft/server";
 
-export function getBlockIoCategories(block: Block): string[] | "any" {
-  if (block.hasTag("fluffyalien_energisticscore:io._any")) return "any";
+const IO_TYPE_TAG_PREFIX = "fluffyalien_energisticscore:io.type.";
+const IO_CATEGORY_TAG_PREFIX = "fluffyalien_energisticscore:io.category.";
 
-  const tags = block.getTags();
-  const categories: string[] = [];
+export interface MachineIo {
+  types: string[];
+  categories: string[];
+}
 
-  for (const tag of tags) {
-    if (tag.startsWith("fluffyalien_energisticscore:io.")) {
-      categories.push(tag.slice("fluffyalien_energisticscore:io.".length));
-    }
-  }
+export function getMachineIo(machine: Block): MachineIo | "any" {
+  const tags = machine.getTags();
 
-  return categories;
+  if (tags.includes("fluffyalien_energisticscore:io.any")) return "any";
+
+  const types = tags.filter((tag) => tag.startsWith(IO_TYPE_TAG_PREFIX));
+  const categories = tags.filter((tag) =>
+    tag.startsWith(IO_CATEGORY_TAG_PREFIX),
+  );
+
+  return {
+    types: types.map((tag) => tag.slice(IO_TYPE_TAG_PREFIX.length)),
+    categories: categories.map((tag) =>
+      tag.slice(IO_CATEGORY_TAG_PREFIX.length),
+    ),
+  };
 }

--- a/public_api/src/io.ts
+++ b/public_api/src/io.ts
@@ -1,27 +1,153 @@
 import { Block } from "@minecraft/server";
+import {
+  RegisteredStorageType,
+  StorageTypeData,
+} from "./storage_type_registry.js";
 
 const IO_TYPE_TAG_PREFIX = "fluffyalien_energisticscore:io.type.";
 const IO_CATEGORY_TAG_PREFIX = "fluffyalien_energisticscore:io.category.";
 
-export interface MachineIo {
+interface MachineIoData {
+  acceptsAny: boolean;
   types: string[];
   categories: string[];
 }
 
-export function getMachineIo(machine: Block): MachineIo | "any" {
-  const tags = machine.getTags();
+/**
+ * An object that represents the input/output capabilities of a machine.
+ * @beta
+ */
+export class MachineIo {
+  private constructor(private readonly data: MachineIoData) {}
 
-  if (tags.includes("fluffyalien_energisticscore:io.any")) return "any";
+  /**
+   * @beta
+   * @returns Returns whether this object accepts any type or category.
+   */
+  get acceptsAny(): boolean {
+    return this.data.acceptsAny;
+  }
 
-  const types = tags.filter((tag) => tag.startsWith(IO_TYPE_TAG_PREFIX));
-  const categories = tags.filter((tag) =>
-    tag.startsWith(IO_CATEGORY_TAG_PREFIX),
-  );
+  /**
+   * @beta
+   * @returns Returns the accepted type IDs (empty if the object accepts any).
+   */
+  get types(): readonly string[] {
+    return this.data.types;
+  }
 
-  return {
-    types: types.map((tag) => tag.slice(IO_TYPE_TAG_PREFIX.length)),
-    categories: categories.map((tag) =>
-      tag.slice(IO_CATEGORY_TAG_PREFIX.length),
-    ),
-  };
+  /**
+   * @beta
+   * @returns Returns the accepted categories (empty if the object accepts any).
+   */
+  get categories(): readonly string[] {
+    return this.data.categories;
+  }
+
+  /**
+   * Check if this object accepts the given storage type.
+   * @beta
+   * @param storageType The storage type data to check.
+   * @returns Whether this object accepts the given storage type.
+   */
+  acceptsType(storageType: StorageTypeData): boolean {
+    return (
+      this.acceptsAny ||
+      this.categories.includes(storageType.category) ||
+      this.types.includes(storageType.id)
+    );
+  }
+
+  /**
+   * Get a storage type by it's ID and check if this object accepts it.
+   * @beta
+   * @param id The ID of the storage type.
+   * @returns Whether this object accepts the storage type with the given ID.
+   */
+  async acceptsTypeWithId(id: string): Promise<boolean> {
+    if (this.acceptsAny) return true;
+
+    const storageType = await RegisteredStorageType.get(id);
+    if (!storageType) return false;
+
+    return this.acceptsType(storageType);
+  }
+
+  /**
+   * Check if this object accepts the given category.
+   * @beta
+   * @param category The category to check.
+   * @returns Whether this object accepts the given category.
+   */
+  acceptsCategory(category: string): boolean {
+    return this.acceptsAny || this.categories.includes(category);
+  }
+
+  /**
+   * Check if this object accepts any storage type of the given category.
+   * @beta
+   * @param category The category to check.
+   * @returns Whether this object accepts any storage type of the given category.
+   */
+  async acceptsAnyTypeOfCategory(category: string): Promise<boolean> {
+    if (this.acceptsCategory(category)) return true;
+
+    for (const type of this.types) {
+      const storageType = await RegisteredStorageType.get(type);
+      if (storageType?.category === category) return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Create a new MachineIo object that accepts the given types and categories.
+   * @beta
+   * @param types Accepted type IDs.
+   * @param categories Accepted categories.
+   * @returns Returns a new MachineIo object.
+   */
+  static accepting(types: string[], categories: string[]): MachineIo {
+    return new MachineIo({
+      acceptsAny: false,
+      types,
+      categories,
+    });
+  }
+
+  /**
+   * Create a new MachineIo object that accepts any type or category.
+   * @beta
+   * @returns Returns a new MachineIo object.
+   */
+  static acceptingAny(): MachineIo {
+    return new MachineIo({
+      acceptsAny: true,
+      types: [],
+      categories: [],
+    });
+  }
+
+  /**
+   * Get the input/output capabilities of a machine.
+   * @beta
+   * @param machine The machine.
+   * @returns A MachineIo object.
+   */
+  static fromMachine(machine: Block): MachineIo {
+    const tags = machine.getTags();
+
+    if (tags.includes("fluffyalien_energisticscore:io.any")) {
+      return MachineIo.acceptingAny();
+    }
+
+    const types = tags
+      .filter((tag) => tag.startsWith(IO_TYPE_TAG_PREFIX))
+      .map((tag) => tag.slice(IO_TYPE_TAG_PREFIX.length));
+    const categories = tags
+      .filter((tag) => tag.startsWith(IO_CATEGORY_TAG_PREFIX))
+      .map((tag) => tag.slice(IO_CATEGORY_TAG_PREFIX.length));
+
+    return MachineIo.accepting(types, categories);
+  }
 }

--- a/public_api/src/machine_data.ts
+++ b/public_api/src/machine_data.ts
@@ -31,7 +31,7 @@ export interface MachineItemStack {
  * @beta
  * @param loc The location of the machine.
  * @param type The type of storage to get.
- * @throws Throws {@link Error} if the storage type does not exist
+ * @throws Throws if the storage type does not exist
  */
 export function getMachineStorage(
   loc: DimensionLocation,

--- a/public_api/src/network.ts
+++ b/public_api/src/network.ts
@@ -17,7 +17,7 @@ import { makeSerializableDimensionLocation } from "./serialize_utils.js";
 import { ipcInvoke, ipcSend } from "./ipc_wrapper.js";
 
 /**
- * A network of machines with a certain I/O category.
+ * A network of machines with a certain I/O type.
  * @beta
  */
 export class MachineNetwork {
@@ -125,7 +125,9 @@ export class MachineNetwork {
 
   /**
    * Get the {@link MachineNetwork} that contains a machine that matches the arguments.
-   * @param category the category of the network.
+   * @param ioTypeId the I/O type of the network.
+   * @param location The location of the machine.
+   * @param connectionType The connection type of the machine.
    * @beta
    */
   static async getWith(
@@ -154,12 +156,12 @@ export class MachineNetwork {
    * @beta
    */
   static async getWithBlock(
-    category: string,
+    ioTypeId: string,
     block: Block,
   ): Promise<MachineNetwork | undefined> {
     const type = getBlockNetworkConnectionType(block);
     if (!type) return;
-    return MachineNetwork.getWith(category, block, type);
+    return MachineNetwork.getWith(ioTypeId, block, type);
   }
 
   /**
@@ -226,24 +228,12 @@ export class MachineNetwork {
    * @param categories Only update networks of these I/O categories. If this is `undefined` then all adjacent networks will be updated.
    * @beta
    */
-  static async updateAdjacent(
-    location: DimensionLocation,
-    categories?: string[],
-  ): Promise<void> {
+  static async updateAdjacent(location: DimensionLocation): Promise<void> {
     for (const directionVector of DIRECTION_VECTORS) {
       const blockInDirection = location.dimension.getBlock(
         Vector3Utils.add(location, directionVector),
       );
       if (!blockInDirection) {
-        continue;
-      }
-
-      if (categories) {
-        for (const category of categories) {
-          void MachineNetwork.getWithBlock(category, blockInDirection).then(
-            (network) => network?.destroy(),
-          );
-        }
         continue;
       }
 

--- a/public_api/src/network.ts
+++ b/public_api/src/network.ts
@@ -225,7 +225,6 @@ export class MachineNetwork {
 
   /**
    * Update all {@link MachineNetwork}s adjacent to a location.
-   * @param categories Only update networks of these I/O categories. If this is `undefined` then all adjacent networks will be updated.
    * @beta
    */
   static async updateAdjacent(location: DimensionLocation): Promise<void> {

--- a/public_api/src/network_internal.ts
+++ b/public_api/src/network_internal.ts
@@ -33,33 +33,16 @@ export interface MangledNetworkQueueSendPayload
 /**
  * @internal
  */
-export interface MangledNetworkEstablishPayload {
-  /**
-   * category
-   */
-  a: string;
-  /**
-   * blockLocation
-   */
-  b: SerializableDimensionLocation;
+export interface NetworkEstablishPayload {
+  ioTypeId: string;
+  location: SerializableDimensionLocation;
 }
 
 /**
  * @internal
  */
-export interface MangledNetworkGetWithPayload {
-  /**
-   * category
-   */
-  a: string;
-  /**
-   * location
-   */
-  b: SerializableDimensionLocation;
-  /**
-   * type
-   */
-  c: NetworkConnectionType;
+export interface NetworkGetWithPayload extends NetworkEstablishPayload {
+  connectionType: NetworkConnectionType;
 }
 
 /**

--- a/public_api/src/network_utils.ts
+++ b/public_api/src/network_utils.ts
@@ -31,7 +31,7 @@ export function getBlockNetworkConnectionType(
  * @param blockLocation The location of the machine that is generating.
  * @param type The storage type to generate.
  * @param amount The amount to generate.
- * @see {@link queueSend}
+ * @see {@link MachineNetwork.queueSend}
  */
 export function generate(
   blockLocation: DimensionLocation,

--- a/public_api/src/storage_type_registry.ts
+++ b/public_api/src/storage_type_registry.ts
@@ -2,12 +2,17 @@ import { ipcInvoke, ipcSend } from "./ipc_wrapper.js";
 import { StorageTypeColor, StorageTypeDefinition } from "./registry_types.js";
 import { MangledStorageTypeDefinition } from "./storage_type_registry_internal.js";
 
+export interface StorageTypeData {
+  id: string;
+  category: string;
+}
+
 /**
  * Representation of a storage type definition that has been registered.
  * @beta
  * @see {@link StorageTypeDefinition}, {@link registerStorageType}
  */
-export class RegisteredStorageType {
+export class RegisteredStorageType implements StorageTypeData {
   /**
    * @internal
    */
@@ -54,7 +59,7 @@ export class RegisteredStorageType {
    * Gets a registered storage type.
    * @beta
    * @param id The ID of the storage type.
-   * @returns The {@link RegisteredStorageType} with the specified `id` or `null` if it doesn't exist.
+   * @returns The {@link RegisteredStorageType} with the specified ID or `undefined` if it doesn't exist.
    * @throws if Bedrock Energistics Core takes too long to respond.
    */
   static async get(id: string): Promise<RegisteredStorageType | undefined> {


### PR DESCRIPTION
Currently, networks are organized by category rather than by type, which means that machine connections behave weirdly.

For example, a fluid conduit passing through a fluid tank that only accepts lava, to a machine. The machine at the end will accept all fluids, even though the conduit passes through a fluid tank that only accepts lava

This PR would organize networks by type, meaning that the machine would only get lava because the fluid tank in between cuts off every other type.

## New I/O Tag System
This PR introduces a new I/O tag system.

New syntax: `io.any` or `io.type.<StorageTypeId>` or `io.category.<StorageCategoryId>`
Updating existing code:
  - `io._any` -> `io.any`
  - `io.<StorageCategoryId>` -> `io.category.<StorageCategoryId>`

The intention is to migrate from using categories for I/O to individual types. However, a machine may still use categories instead of types if necessary.

## `MachineIo` Public API Class
Due to the more complex I/O tag system, it is less intuitive to read this data from scripts.

To fix this, this PR introduces a `MachineIo` utility class in the public API which represents machine I/O data and provides many utility methods for working with it.

The `MachineIo` class replaces the `getBlockIoCategories` function.

## API Changelog
- remove `getBlockIoCategories` function
- remove `MachineNetwork#updateConnectable` function - use `MachineNetwork#updateAdjacent` function instead
- add `MachineIo` class
- add `StorageTypeData` interface