### PR TITLE
Merge #79 to item-machines

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
-{}
+{
+  "endOfLine": "crlf"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
+    "**/.regolith": true,
+    "**/node_modules": true,
+    "**/package-lock.json": true,
+    "public_api/dist": true,
+    "public_api/docs": true
+  }
+}

--- a/packs/BP/scripts/utils/direction.ts
+++ b/packs/BP/scripts/utils/direction.ts
@@ -124,3 +124,20 @@ export function reverseDirection(
 export function isCardinalDirection(direction: string): boolean {
   return (STR_CARDINAL_DIRECTIONS as readonly string[]).includes(direction);
 }
+
+export function strDirectionToDirection(strDir: StrDirection): Direction {
+  switch (strDir) {
+    case "north":
+      return Direction.North;
+    case "east":
+      return Direction.East;
+    case "south":
+      return Direction.South;
+    case "west":
+      return Direction.West;
+    case "up":
+      return Direction.Up;
+    case "down":
+      return Direction.Down;
+  }
+}

--- a/public_api/src/network.ts
+++ b/public_api/src/network.ts
@@ -41,7 +41,7 @@ export class MachineNetwork {
       a: this.id,
     };
 
-    ipcSend("fluffyalien_energisisticscore:ipc.networkDestroy", payload);
+    ipcSend("fluffyalien_energisticscore:ipc.networkDestroy", payload);
   }
 
   /**


### PR DESCRIPTION
- BREAKING: api: replace `MachineIo` with `MachineSideIo`, now only represents one side of a machine, not the whole machine.
- new explicit sides tag syntax: `fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side}` or `fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side}` (the `fluffyalien_energisticscore:explicit_sides` tag must also be added to use this syntax, otherwise the normal syntax would be expected)
- api: fix IPC event typo in `MachineNetwork#destroy`