### PR TITLE
Update `mcbe-addon-ipc` and Better Internal IPC APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@minecraft/math": "^1.4.0",
-        "mcbe-addon-ipc": "=0.4.0"
+        "mcbe-addon-ipc": "file:../../mcbe-addon-ipc"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -21,6 +21,23 @@
         "typedoc": "^0.26.5",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.1.0"
+      }
+    },
+    "../../mcbe-addon-ipc": {
+      "version": "0.4.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@eslint/js": "^9.9.0",
+        "@minecraft/server": "^1.13.0",
+        "@types/eslint__js": "^8.42.3",
+        "eslint": "^9.9.0",
+        "prettier": "^3.3.3",
+        "typedoc": "^0.26.5",
+        "typescript": "^5.5.4",
+        "typescript-eslint": "^8.1.0"
+      },
+      "peerDependencies": {
+        "@minecraft/server": "^1.13.0"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -1373,11 +1390,8 @@
       }
     },
     "node_modules/mcbe-addon-ipc": {
-      "version": "0.4.0",
-      "license": "ISC",
-      "peerDependencies": {
-        "@minecraft/server": "^1.13.0"
-      }
+      "resolved": "../../mcbe-addon-ipc",
+      "link": true
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@minecraft/math": "^1.4.0",
-        "mcbe-addon-ipc": "file:../../mcbe-addon-ipc"
+        "mcbe-addon-ipc": "0.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -21,23 +21,6 @@
         "typedoc": "^0.26.5",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.1.0"
-      }
-    },
-    "../../mcbe-addon-ipc": {
-      "version": "0.4.0",
-      "license": "ISC",
-      "devDependencies": {
-        "@eslint/js": "^9.9.0",
-        "@minecraft/server": "^1.13.0",
-        "@types/eslint__js": "^8.42.3",
-        "eslint": "^9.9.0",
-        "prettier": "^3.3.3",
-        "typedoc": "^0.26.5",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.1.0"
-      },
-      "peerDependencies": {
-        "@minecraft/server": "^1.13.0"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -1390,8 +1373,13 @@
       }
     },
     "node_modules/mcbe-addon-ipc": {
-      "resolved": "../../mcbe-addon-ipc",
-      "link": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mcbe-addon-ipc/-/mcbe-addon-ipc-0.5.0.tgz",
+      "integrity": "sha512-zkhm2wsBTmvcGny6CP9PDE39NS2M8r/ivo9OTAVL7566WwOjusM5GXK4s3rE/1x9XIWge8DyjBODxDcAlA4/lg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@minecraft/server": "^1.13.0"
+      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@minecraft/math": "^1.4.0",
-    "mcbe-addon-ipc": "=0.4.0"
+    "mcbe-addon-ipc": "file:../../mcbe-addon-ipc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@minecraft/math": "^1.4.0",
-    "mcbe-addon-ipc": "file:../../mcbe-addon-ipc"
+    "mcbe-addon-ipc": "0.5.0"
   }
 }

--- a/packs/BP/scripts/ipc_listeners.ts
+++ b/packs/BP/scripts/ipc_listeners.ts
@@ -1,4 +1,3 @@
-import * as ipc from "mcbe-addon-ipc";
 import { MachineItemStack } from "@/public_api/src";
 import { setMachineSlotItem } from "./data";
 import {
@@ -31,6 +30,8 @@ import {
   InternalRegisteredStorageType,
   registerStorageTypeListener,
 } from "./storage_type_registry";
+import { registerListener } from "./ipc_wrapper";
+import { BecIpcListener } from "@/public_api/src/bec_ipc_listener";
 
 interface SetItemInMachineSlotPayload {
   loc: SerializableDimensionLocation;
@@ -38,119 +39,64 @@ interface SetItemInMachineSlotPayload {
   item?: MachineItemStack;
 }
 
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.registerMachine",
-  registerMachineListener,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.registerStorageType",
+registerListener(BecIpcListener.RegisterMachine, registerMachineListener);
+registerListener(
+  BecIpcListener.RegisterStorageType,
   registerStorageTypeListener,
 );
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.setMachineSlot",
-  (payload_) => {
-    const payload = payload_ as SetItemInMachineSlotPayload;
-    setMachineSlotItem(
-      deserializeDimensionLocation(payload.loc),
-      payload.slot,
-      payload.item,
-    );
-    return null;
-  },
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkDestroy",
-  networkDestroyListener,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkQueueSend",
-  networkQueueSendListener,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.generate",
-  generateListener,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkEstablish",
-  networkEstablishHandler,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkGetWith",
-  networkGetWithHandler,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkGetAllWith",
-  networkGetAllWithHandler,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkGetOrEstablish",
+registerListener(BecIpcListener.SetMachineSlot, (payload_) => {
+  const payload = payload_ as SetItemInMachineSlotPayload;
+  setMachineSlotItem(
+    deserializeDimensionLocation(payload.loc),
+    payload.slot,
+    payload.item,
+  );
+  return null;
+});
+registerListener(BecIpcListener.DestroyNetwork, networkDestroyListener);
+registerListener(BecIpcListener.NetworkQueueSend, networkQueueSendListener);
+registerListener(BecIpcListener.Generate, generateListener);
+registerListener(BecIpcListener.EstablishNetwork, networkEstablishHandler);
+registerListener(BecIpcListener.GetNetworkWith, networkGetWithHandler);
+registerListener(BecIpcListener.GetAllNetworksWith, networkGetAllWithHandler);
+registerListener(
+  BecIpcListener.GetOrEstablishNetwork,
   networkGetOrEstablishHandler,
 );
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkIsPartOfNetwork",
-  networkIsPartOfNetworkHandler,
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.registeredMachineGet",
+registerListener(BecIpcListener.IsPartOfNetwork, networkIsPartOfNetworkHandler);
+registerListener(
+  BecIpcListener.GetRegisteredMachine,
   (payload) =>
     InternalRegisteredMachine.getInternal(payload as string)?.getData() ?? null,
 );
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.registeredStorageTypeGet",
+registerListener(
+  BecIpcListener.GetRegisteredStorageType,
   (payload) =>
     InternalRegisteredStorageType.getInternal(
       payload as string,
     )?.getDefinition() ?? null,
 );
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkLinkGet",
-  (payload) => {
-    const data = payload as NetworkLinkGetRequest;
-    const link = getNetworkLinkNode(data.self);
-    const result: NetworkLinkGetResponse = { locations: link.getConnections() };
-    return result;
-  },
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkLinkAdd",
-  (payload) => {
-    const data = payload as NetworkLinkAddRequest;
-    const link = getNetworkLinkNode(data.self);
-    link.addConnection(data.other);
-    return null;
-  },
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkLinkRemove",
-  (payload) => {
-    const data = payload as NetworkLinkRemoveRequest;
-    const link = getNetworkLinkNode(data.self);
-    link.removeConnection(data.other);
-    return null;
-  },
-);
-
-ipc.registerListener(
-  "fluffyalien_energisticscore:ipc.networkLinkDestroy",
-  (payload) => {
-    const data = payload as NetworkLinkDestroyRequest;
-    const link = getNetworkLinkNode(data.self);
-    link.destroyNode();
-    return null;
-  },
-);
+registerListener(BecIpcListener.GetNetworkLink, (payload) => {
+  const data = payload as NetworkLinkGetRequest;
+  const link = getNetworkLinkNode(data.self);
+  const result: NetworkLinkGetResponse = { locations: link.getConnections() };
+  return result;
+});
+registerListener(BecIpcListener.AddNetworkLink, (payload) => {
+  const data = payload as NetworkLinkAddRequest;
+  const link = getNetworkLinkNode(data.self);
+  link.addConnection(data.other);
+  return null;
+});
+registerListener(BecIpcListener.RemoveNetworkLink, (payload) => {
+  const data = payload as NetworkLinkRemoveRequest;
+  const link = getNetworkLinkNode(data.self);
+  link.removeConnection(data.other);
+  return null;
+});
+registerListener(BecIpcListener.DestroyNetworkLink, (payload) => {
+  const data = payload as NetworkLinkDestroyRequest;
+  const link = getNetworkLinkNode(data.self);
+  link.destroyNode();
+  return null;
+});

--- a/packs/BP/scripts/ipc_wrapper.ts
+++ b/packs/BP/scripts/ipc_wrapper.ts
@@ -1,20 +1,23 @@
+import { BecIpcListener } from "@/public_api/src/bec_ipc_listener";
 import * as ipc from "mcbe-addon-ipc";
 
+export const ipcRouter = new ipc.Router("fluffyalien_energisticscore_router");
+
+export function registerListener(
+  id: BecIpcListener,
+  listener: (payload: ipc.SerializableValue) => ipc.SerializableValue,
+): void {
+  ipcRouter.registerListener(id, listener as ipc.ScriptEventListener);
+}
+
 export function ipcSend(event: string, payload: ipc.SerializableValue): void {
-  void ipc.sendAuto({
-    event,
-    payload,
-    namespace: "fluffyalien_energisticscore",
-  });
+  void ipcRouter.sendAuto({ event, payload });
 }
 
 export function ipcInvoke(
   event: string,
   payload: ipc.SerializableValue,
+  throwFailures = true,
 ): Promise<ipc.SerializableValue> {
-  return ipc.invokeAuto({
-    event,
-    payload,
-    namespace: "fluffyalien_energisticscore",
-  });
+  return ipcRouter.invokeAuto({ event, payload, throwFailures });
 }

--- a/public_api/package-lock.json
+++ b/public_api/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "bedrock-energistics-core-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bedrock-energistics-core-api",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
-        "mcbe-addon-ipc": "=0.4.0"
+        "mcbe-addon-ipc": "file:../../../mcbe-addon-ipc"
       },
       "devDependencies": {
         "@minecraft/server": "=1.15.0"
@@ -18,23 +18,39 @@
         "@minecraft/server": "^1.15.0"
       }
     },
+    "../../../mcbe-addon-ipc": {
+      "version": "0.4.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@eslint/js": "^9.9.0",
+        "@minecraft/server": "^1.13.0",
+        "@types/eslint__js": "^8.42.3",
+        "eslint": "^9.9.0",
+        "prettier": "^3.3.3",
+        "typedoc": "^0.26.5",
+        "typescript": "^5.5.4",
+        "typescript-eslint": "^8.1.0"
+      },
+      "peerDependencies": {
+        "@minecraft/server": "^1.13.0"
+      }
+    },
     "node_modules/@minecraft/common": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@minecraft/server": {
       "version": "1.15.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.1.0"
       }
     },
     "node_modules/mcbe-addon-ipc": {
-      "version": "0.4.0",
-      "license": "ISC",
-      "peerDependencies": {
-        "@minecraft/server": "^1.13.0"
-      }
+      "resolved": "../../../mcbe-addon-ipc",
+      "link": true
     }
   }
 }

--- a/public_api/package-lock.json
+++ b/public_api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
-        "mcbe-addon-ipc": "file:../../../mcbe-addon-ipc"
+        "mcbe-addon-ipc": "0.5.0"
       },
       "devDependencies": {
         "@minecraft/server": "=1.15.0"
@@ -18,39 +18,25 @@
         "@minecraft/server": "^1.15.0"
       }
     },
-    "../../../mcbe-addon-ipc": {
-      "version": "0.4.0",
-      "license": "ISC",
-      "devDependencies": {
-        "@eslint/js": "^9.9.0",
-        "@minecraft/server": "^1.13.0",
-        "@types/eslint__js": "^8.42.3",
-        "eslint": "^9.9.0",
-        "prettier": "^3.3.3",
-        "typedoc": "^0.26.5",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.1.0"
-      },
-      "peerDependencies": {
-        "@minecraft/server": "^1.13.0"
-      }
-    },
     "node_modules/@minecraft/common": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@minecraft/server": {
       "version": "1.15.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.1.0"
       }
     },
     "node_modules/mcbe-addon-ipc": {
-      "resolved": "../../../mcbe-addon-ipc",
-      "link": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mcbe-addon-ipc/-/mcbe-addon-ipc-0.5.0.tgz",
+      "integrity": "sha512-zkhm2wsBTmvcGny6CP9PDE39NS2M8r/ivo9OTAVL7566WwOjusM5GXK4s3rE/1x9XIWge8DyjBODxDcAlA4/lg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@minecraft/server": "^1.13.0"
+      }
     }
   }
 }

--- a/public_api/package.json
+++ b/public_api/package.json
@@ -28,6 +28,6 @@
     "@minecraft/server": "^1.15.0"
   },
   "dependencies": {
-    "mcbe-addon-ipc": "file:../../../mcbe-addon-ipc"
+    "mcbe-addon-ipc": "0.5.0"
   }
 }

--- a/public_api/package.json
+++ b/public_api/package.json
@@ -28,6 +28,6 @@
     "@minecraft/server": "^1.15.0"
   },
   "dependencies": {
-    "mcbe-addon-ipc": "=0.4.0"
+    "mcbe-addon-ipc": "file:../../../mcbe-addon-ipc"
   }
 }

--- a/public_api/src/bec_ipc_listener.ts
+++ b/public_api/src/bec_ipc_listener.ts
@@ -1,0 +1,23 @@
+/**
+ * @internal
+ */
+export enum BecIpcListener {
+  RegisterMachine = "fluffyalien_energisticscore:ipc.registerMachine",
+  RegisterStorageType = "fluffyalien_energisticscore:ipc.registerStorageType",
+  SetMachineSlot = "fluffyalien_energisticscore:ipc.setMachineSlot",
+  DestroyNetwork = "fluffyalien_energisticscore:ipc.destroyNetwork",
+  NetworkQueueSend = "fluffyalien_energisticscore:ipc.networkQueueSend",
+  Generate = "fluffyalien_energisticscore:ipc.generate",
+  EstablishNetwork = "fluffyalien_energisticscore:ipc.establishNetwork",
+  GetNetworkWith = "fluffyalien_energisticscore:ipc.getNetworkWith",
+  GetAllNetworksWith = "fluffyalien_energisticscore:ipc.getAllNetworksWith",
+  GetOrEstablishNetwork = "fluffyalien_energisticscore:ipc.getOrEstablishNetwork",
+  IsPartOfNetwork = "fluffyalien_energisticscore:ipc.isPartOfNetwork",
+  GetRegisteredMachine = "fluffyalien_energisticscore:ipc.getRegisteredMachine",
+  GetRegisteredStorageType = "fluffyalien_energisticscore:ipc.getRegisteredStorageType",
+  GetNetworkLink = "fluffyalien_energisticscore:ipc.getNetworkLink",
+  AddNetworkLink = "fluffyalien_energisticscore:ipc.addNetworkLink",
+  RemoveNetworkLink = "fluffyalien_energisticscore:ipc.removeNetworkLink",
+  DestroyNetworkLink = "fluffyalien_energisticscore:ipc.destroyNetworkLink",
+}
+

--- a/public_api/src/init.ts
+++ b/public_api/src/init.ts
@@ -1,26 +1,27 @@
+import * as ipc from "mcbe-addon-ipc";
 import { raise } from "./log.js";
 
-let initNamespace: string | undefined;
+let ipcRouter: ipc.Router | undefined;
 
 /**
  * Initializes this package. Some APIs require this to be called.
  * @beta
  */
 export function init(namespace: string): void {
-  if (initNamespace) {
+  if (ipcRouter) {
     raise("Library already initialized.");
   }
 
-  initNamespace = namespace;
+  ipcRouter = new ipc.Router(namespace);
 }
 
 /**
  * @internal
  */
-export function getNamespace(): string {
-  if (!initNamespace) {
+export function getIpcRouter(): ipc.Router {
+  if (!ipcRouter) {
     raise("Library not initialized.");
   }
 
-  return initNamespace;
+  return ipcRouter;
 }

--- a/public_api/src/ipc_wrapper.ts
+++ b/public_api/src/ipc_wrapper.ts
@@ -1,19 +1,24 @@
 import * as ipc from "mcbe-addon-ipc";
-import { getNamespace } from "./init.js";
+import { getIpcRouter } from "./init.js";
+import { BecIpcListener } from "./bec_ipc_listener.js";
 
 /**
  * @internal
  */
-export function ipcSend(event: string, payload: ipc.SerializableValue): void {
-  void ipc.sendAuto({ event, payload, namespace: getNamespace() });
+export function ipcSend(
+  event: BecIpcListener,
+  payload: ipc.SerializableValue,
+): void {
+  void getIpcRouter().sendAuto({ event, payload });
 }
 
 /**
  * @internal
  */
 export function ipcInvoke(
-  event: string,
+  event: BecIpcListener,
   payload: ipc.SerializableValue,
+  throwFailures = true,
 ): Promise<ipc.SerializableValue> {
-  return ipc.invokeAuto({ event, payload, namespace: getNamespace() });
+  return getIpcRouter().invokeAuto({ event, payload, throwFailures });
 }

--- a/public_api/src/machine_data.ts
+++ b/public_api/src/machine_data.ts
@@ -9,6 +9,7 @@ import {
 import { makeErrorString } from "./log.js";
 import { makeSerializableDimensionLocation } from "./serialize_utils.js";
 import { ipcSend } from "./ipc_wrapper.js";
+import { BecIpcListener } from "./bec_ipc_listener.js";
 
 /**
  * Representation of an item stack stored in a machine inventory.
@@ -140,7 +141,7 @@ export function setMachineSlotItem(
   slotId: number,
   newItemStack?: MachineItemStack,
 ): void {
-  ipcSend("fluffyalien_energisticscore:ipc.setMachineSlot", {
+  ipcSend(BecIpcListener.SetMachineSlot, {
     loc: makeSerializableDimensionLocation(loc),
     slot: slotId,
     item: newItemStack,

--- a/public_api/src/network.ts
+++ b/public_api/src/network.ts
@@ -15,6 +15,7 @@ import {
 } from "./network_utils.js";
 import { makeSerializableDimensionLocation } from "./serialize_utils.js";
 import { ipcInvoke, ipcSend } from "./ipc_wrapper.js";
+import { BecIpcListener } from "./bec_ipc_listener.js";
 
 /**
  * A network of machines with a certain I/O type.
@@ -41,7 +42,7 @@ export class MachineNetwork {
       a: this.id,
     };
 
-    ipcSend("fluffyalien_energisticscore:ipc.networkDestroy", payload);
+    ipcSend(BecIpcListener.DestroyNetwork, payload);
   }
 
   /**
@@ -59,7 +60,7 @@ export class MachineNetwork {
     };
 
     return ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkIsPartOfNetwork",
+      BecIpcListener.IsPartOfNetwork,
       payload,
     ) as Promise<boolean>;
   }
@@ -97,7 +98,7 @@ export class MachineNetwork {
       d: amount,
     };
 
-    ipcSend("fluffyalien_energisisticscore:ipc.networkQueueSend", payload);
+    ipcSend(BecIpcListener.NetworkQueueSend, payload);
   }
 
   /**
@@ -113,10 +114,9 @@ export class MachineNetwork {
       location: makeSerializableDimensionLocation(location),
     };
 
-    const id = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkEstablish",
-      payload,
-    )) as number | null;
+    const id = (await ipcInvoke(BecIpcListener.EstablishNetwork, payload)) as
+      | number
+      | null;
 
     if (id) {
       return new MachineNetwork(id);
@@ -141,10 +141,9 @@ export class MachineNetwork {
       location: makeSerializableDimensionLocation(location),
     };
 
-    const id = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkGetWith",
-      payload,
-    )) as number | null;
+    const id = (await ipcInvoke(BecIpcListener.GetNetworkWith, payload)) as
+      | number
+      | null;
 
     if (id) {
       return new MachineNetwork(id);
@@ -178,7 +177,7 @@ export class MachineNetwork {
     };
 
     const ids = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkGetAllWith",
+      BecIpcListener.GetAllNetworksWith,
       payload,
     )) as number[];
 
@@ -214,7 +213,7 @@ export class MachineNetwork {
     };
 
     const id = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkGetOrEstablish",
+      BecIpcListener.GetOrEstablishNetwork,
       payload,
     )) as number | null;
 

--- a/public_api/src/network_links/network_link_node.ts
+++ b/public_api/src/network_links/network_link_node.ts
@@ -10,6 +10,7 @@ import {
 import { makeSerializableDimensionLocation } from "../serialize_utils.js";
 import { raise } from "../log.js";
 import { ipcInvoke } from "../ipc_wrapper.js";
+import { BecIpcListener } from "../bec_ipc_listener.js";
 
 /**
  * A network link node in a machine network.
@@ -40,7 +41,7 @@ export class NetworkLinkNode {
     };
 
     const res = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkLinkGet",
+      BecIpcListener.GetNetworkLink,
       payload,
     )) as NetworkLinkGetResponse;
 
@@ -61,7 +62,7 @@ export class NetworkLinkNode {
       other: location,
     };
 
-    await ipcInvoke("fluffyalien_energisticscore:ipc.networkLinkAdd", payload);
+    await ipcInvoke(BecIpcListener.AddNetworkLink, payload);
   }
 
   /**
@@ -78,10 +79,7 @@ export class NetworkLinkNode {
       other: location,
     };
 
-    await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkLinkRemove",
-      payload,
-    );
+    await ipcInvoke(BecIpcListener.RemoveNetworkLink, payload);
   }
 
   /**
@@ -96,10 +94,7 @@ export class NetworkLinkNode {
       }),
     };
 
-    await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.networkLinkDestroy",
-      payload,
-    );
+    await ipcInvoke(BecIpcListener.DestroyNetworkLink, payload);
   }
 
   /**

--- a/public_api/src/network_utils.ts
+++ b/public_api/src/network_utils.ts
@@ -2,6 +2,7 @@ import { Block, BlockPermutation, DimensionLocation } from "@minecraft/server";
 import { MangledGeneratePayload } from "./network_internal.js";
 import { makeSerializableDimensionLocation } from "./serialize_utils.js";
 import { ipcSend } from "./ipc_wrapper.js";
+import { BecIpcListener } from "./bec_ipc_listener.js";
 
 /**
  * @beta
@@ -50,5 +51,5 @@ export function generate(
     c: amount,
   };
 
-  ipcSend("fluffyalien_energisticscore:ipc.generate", payload);
+  ipcSend(BecIpcListener.Generate, payload);
 }

--- a/public_api/src/storage_type_registry.ts
+++ b/public_api/src/storage_type_registry.ts
@@ -1,3 +1,4 @@
+import { BecIpcListener } from "./bec_ipc_listener.js";
 import { ipcInvoke, ipcSend } from "./ipc_wrapper.js";
 import { raise } from "./log.js";
 import { isRegistrationAllowed } from "./registration_allowed.js";
@@ -73,7 +74,7 @@ export class RegisteredStorageType implements StorageTypeData {
     }
 
     const def = (await ipcInvoke(
-      "fluffyalien_energisticscore:ipc.registeredStorageTypeGet",
+      BecIpcListener.GetRegisteredStorageType,
       id,
     )) as StorageTypeDefinition | null;
 
@@ -114,5 +115,5 @@ export function registerStorageType(definition: StorageTypeDefinition): void {
     name: definition.name,
   };
 
-  ipcSend("fluffyalien_energisticscore:ipc.registerStorageType", payload);
+  ipcSend(BecIpcListener.RegisterStorageType, payload);
 }


### PR DESCRIPTION
## Update `mcbe-addon-ipc`
Update to the latest version of `mcbe-addon-ipc` (v0.5.0), which contains breaking changes. See [changelog](https://github.com/Fluffyalien1422/mcbe-addon-ipc/releases/tag/v0.5.0).

## `BecIpcListener`
This PR also cleans up the internal IPC APIs and introduces a `BecIpcListener` enum to prevent typos in event IDs.

**Example uses:**
```ts
registerListener(BecIpcListener.RegisterMachine, registerMachineListener);
```
```ts
ipcSend(BecIpcListener.DestroyNetwork, payload);
```