### PR TITLE
feat: Allow receive handlers to handle setting storage themselves

### DIFF
--- a/docs/featured_addons.js
+++ b/docs/featured_addons.js
@@ -44,4 +44,3 @@ for (const addon of shuffledFeaturedAddons) {
 
   container.appendChild(a);
 }
-

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -17,6 +17,7 @@ children:
 # Guides
 
 ## Index
+
 - [Conduits](conduits.md)
 - [Debug Stick](debug-stick.md)
 - [Getting Started](getting-started.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bedrock-energistics-core",
+  "name": "Bedrock-Energistics-Core",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packs/BP/scripts/machine_registry.ts
+++ b/packs/BP/scripts/machine_registry.ts
@@ -3,6 +3,7 @@ import { DimensionLocation } from "@minecraft/server";
 import { logInfo, makeErrorString, raise } from "./utils/log";
 import {
   NetworkStorageTypeData,
+  RecieveHandlerResponse,
   RegisteredMachine,
   UpdateUiHandlerResponse,
 } from "@/public_api/src";
@@ -50,7 +51,7 @@ export class InternalRegisteredMachine extends RegisteredMachine {
     blockLocation: DimensionLocation,
     recieveType: string,
     recieveAmount: number,
-  ): Promise<number> {
+  ): Promise<RecieveHandlerResponse> {
     if (!this.data.receiveHandlerEvent) {
       throw new Error(
         makeErrorString(
@@ -65,7 +66,7 @@ export class InternalRegisteredMachine extends RegisteredMachine {
       c: recieveAmount,
     };
 
-    return ipcInvoke(this.data.receiveHandlerEvent, payload) as Promise<number>;
+    return ipcInvoke(this.data.receiveHandlerEvent, payload) as Promise<RecieveHandlerResponse>;
   }
 
   callOnNetworkStatsRecievedEvent(

--- a/packs/BP/scripts/machine_registry.ts
+++ b/packs/BP/scripts/machine_registry.ts
@@ -66,7 +66,10 @@ export class InternalRegisteredMachine extends RegisteredMachine {
       c: recieveAmount,
     };
 
-    return ipcInvoke(this.data.receiveHandlerEvent, payload) as Promise<RecieveHandlerResponse>;
+    return ipcInvoke(
+      this.data.receiveHandlerEvent,
+      payload,
+    ) as Promise<RecieveHandlerResponse>;
   }
 
   callOnNetworkStatsRecievedEvent(

--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -16,6 +16,7 @@ import {
   IoCapabilities,
   NetworkConnectionType,
   NetworkStorageTypeData,
+  RecieveHandlerResponse,
   StorageTypeData,
 } from "@/public_api/src";
 import { InternalRegisteredMachine } from "./machine_registry";
@@ -202,6 +203,7 @@ export class MachineNetwork extends DestroyableObject {
         );
 
         let waiting = true;
+        let shouldHandleStorage = true;
 
         this.determineActualMachineAllocation(
           machine,
@@ -209,7 +211,10 @@ export class MachineNetwork extends DestroyableObject {
           type,
           amountToAllocate,
         )
-          .then((v) => (amountToAllocate = v))
+          .then((v) => {
+            amountToAllocate = v.amount;
+            shouldHandleStorage = v.handleStorage ?? true;
+          })
           .catch((e: unknown) => {
             logWarn(
               `Error in determineActualMachineAllocation for id: ${machineDef.id}, error: ${JSON.stringify(e)}`,
@@ -224,7 +229,9 @@ export class MachineNetwork extends DestroyableObject {
 
         // finally give the machine its allocated share
         budget -= amountToAllocate;
-        setMachineStorage(machine, type, currentStored + amountToAllocate);
+        if (shouldHandleStorage as boolean) {
+          setMachineStorage(machine, type, currentStored + amountToAllocate);
+        } 
         if (budget <= 0) break;
         yield;
       }
@@ -252,6 +259,7 @@ export class MachineNetwork extends DestroyableObject {
             machineDef.maxStorage - currentStored,
           );
 
+          let shouldHandleStorage = true;
           let waiting = true;
 
           this.determineActualMachineAllocation(
@@ -260,7 +268,10 @@ export class MachineNetwork extends DestroyableObject {
             type,
             amountToAllocate,
           )
-            .then((v) => (amountToAllocate = v))
+            .then((v) => {
+              amountToAllocate = v.amount
+              shouldHandleStorage = v.handleStorage ?? true;
+            })
             .catch((e: unknown) => {
               logWarn(
                 `Error in determineActualMachineAllocation for id: ${machineDef.id}, error: ${JSON.stringify(e)}`,
@@ -275,11 +286,13 @@ export class MachineNetwork extends DestroyableObject {
 
           // finally give the machine its allocated share
           budget -= amountToAllocate;
-          setMachineStorage(machine, type, currentStored + amountToAllocate);
+          if (shouldHandleStorage as boolean) {
+            setMachineStorage(machine, type, currentStored + amountToAllocate);
+          }
           if (budget <= 0) break;
           yield;
         }
-      }
+      } 
 
       networkStats[type] = {
         before: originalBudget,
@@ -365,14 +378,16 @@ export class MachineNetwork extends DestroyableObject {
     machineDef: InternalRegisteredMachine,
     type: string,
     amount: number,
-  ): Promise<number> {
+  ): Promise<RecieveHandlerResponse> {
     // Allow the machine to change how much of its allocation it chooses to take
     if (machineDef.getData().receiveHandlerEvent) {
       return machineDef.invokeRecieveHandler(machine, type, amount);
     }
 
     // if no handler, give it everything in its allocation
-    return amount;
+    return {
+      amount
+    }
   }
 
   /**

--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -231,7 +231,7 @@ export class MachineNetwork extends DestroyableObject {
         budget -= amountToAllocate;
         if (shouldHandleStorage as boolean) {
           setMachineStorage(machine, type, currentStored + amountToAllocate);
-        } 
+        }
         if (budget <= 0) break;
         yield;
       }
@@ -269,7 +269,7 @@ export class MachineNetwork extends DestroyableObject {
             amountToAllocate,
           )
             .then((v) => {
-              amountToAllocate = v.amount
+              amountToAllocate = v.amount;
               shouldHandleStorage = v.handleStorage ?? true;
             })
             .catch((e: unknown) => {
@@ -292,7 +292,7 @@ export class MachineNetwork extends DestroyableObject {
           if (budget <= 0) break;
           yield;
         }
-      } 
+      }
 
       networkStats[type] = {
         before: originalBudget,
@@ -386,8 +386,8 @@ export class MachineNetwork extends DestroyableObject {
 
     // if no handler, give it everything in its allocation
     return {
-      amount
-    }
+      amount,
+    };
   }
 
   /**

--- a/public_api/src/machine_registry.ts
+++ b/public_api/src/machine_registry.ts
@@ -144,12 +144,13 @@ export function registerMachine(definition: MachineDefinition): void {
 
     ipcRouter.registerListener(receiveHandlerEvent, (payload) => {
       const data = payload as MangledRecieveHandlerPayload;
+
       return (
         callback({
           blockLocation: deserializeDimensionLocation(data.a),
           receiveType: data.b,
           receiveAmount: data.c,
-        }) ?? data.c
+        })
       );
     });
   }

--- a/public_api/src/machine_registry.ts
+++ b/public_api/src/machine_registry.ts
@@ -145,13 +145,11 @@ export function registerMachine(definition: MachineDefinition): void {
     ipcRouter.registerListener(receiveHandlerEvent, (payload) => {
       const data = payload as MangledRecieveHandlerPayload;
 
-      return (
-        callback({
-          blockLocation: deserializeDimensionLocation(data.a),
-          receiveType: data.b,
-          receiveAmount: data.c,
-        })
-      );
+      return callback({
+        blockLocation: deserializeDimensionLocation(data.a),
+        receiveType: data.b,
+        receiveAmount: data.c,
+      });
     });
   }
 

--- a/public_api/src/machine_registry_types.ts
+++ b/public_api/src/machine_registry_types.ts
@@ -270,7 +270,7 @@ export interface MachineDefinition {
 
 export interface RecieveHandlerResponse {
   /**
-   * How much was recieved
+   * Override the amount to recieve.
    */
   amount: number;
 
@@ -278,7 +278,7 @@ export interface RecieveHandlerResponse {
    * Should the API handle setting machine storage?
    * - Note the API setting incurs a tick delay, for blocks where the tick order is important, this can help avoid race-conditions.
    *
-   * Default value: true
+   * @default true
    */
   handleStorage?: boolean;
 }

--- a/public_api/src/machine_registry_types.ts
+++ b/public_api/src/machine_registry_types.ts
@@ -254,7 +254,7 @@ export interface MachineDefinitionHandlers {
    * (must be a non-negative integer),
    * or `undefined` to not change anything.
    */
-  receive?: MachineCallback<MachineRecieveHandlerArg, number | undefined>;
+  receive?: MachineCallback<MachineRecieveHandlerArg, RecieveHandlerResponse>;
 }
 
 // registered machine
@@ -266,4 +266,19 @@ export interface MachineDefinition {
   description: MachineDefinitionDescription;
   handlers?: MachineDefinitionHandlers;
   events?: MachineDefinitionEvents;
+}
+
+export interface RecieveHandlerResponse {
+  /**
+   * How much was recieved
+   */
+  amount: number;
+
+  /**
+   * Should the API handle setting machine storage?
+   * - Note the API setting incurs a tick delay, for blocks where the tick order is important, this can help avoid race-conditions.
+   * 
+   * Default value: true
+   */
+  handleStorage?: boolean;
 }

--- a/public_api/src/machine_registry_types.ts
+++ b/public_api/src/machine_registry_types.ts
@@ -277,7 +277,7 @@ export interface RecieveHandlerResponse {
   /**
    * Should the API handle setting machine storage?
    * - Note the API setting incurs a tick delay, for blocks where the tick order is important, this can help avoid race-conditions.
-   * 
+   *
    * Default value: true
    */
   handleStorage?: boolean;


### PR DESCRIPTION
As discussed yesterday, here is the new logic for receive handlers to allow them to handle setting machine storage themselves

This comes with breaking changes to any machines using the receive event, since now they will need to be changed to return an object, but I think this is better than having three different types it could possibly be returning