### PR TITLE
Machine Inventory API Revamp

### DIFF
--- a/packs/BP/scripts/data.ts
+++ b/packs/BP/scripts/data.ts
@@ -1,27 +1,19 @@
 import { Block, DimensionLocation, ItemStack } from "@minecraft/server";
 import { machineChangedItemSlots } from "./ui";
-import {
-  MachineItemStack,
-  getMachineSlotItem,
-  UiItemSlotElementDefinition,
-  getMachineStorage,
-} from "@/public_api/src";
+import { MachineItemStack, getMachineStorage } from "@/public_api/src";
 import {
   getBlockUniqueId,
-  getItemTypeScoreboardObjective,
-  getItemCountScoreboardObjective,
   removeBlockFromScoreboards,
   getStorageScoreboardObjective,
 } from "@/public_api/src/machine_data_internal";
 import { raise } from "./utils/log";
 import { InternalRegisteredMachine } from "./machine_registry";
+import {
+  getBlockDynamicProperty,
+  setBlockDynamicProperty,
+} from "./utils/dynamic_property";
 
-export {
-  getBlockUniqueId,
-  getMachineStorage,
-  getMachineSlotItem,
-  removeBlockFromScoreboards,
-};
+export { getBlockUniqueId, getMachineStorage, removeBlockFromScoreboards };
 
 /**
  * Sets the storage of a specific type in a machine.
@@ -69,6 +61,33 @@ export function setMachineStorage(
   }
 }
 
+export function getMachineSlotItem(
+  loc: DimensionLocation,
+  slot: number,
+): MachineItemStack | undefined {
+  const itemTypePropertyId = `itemType${slot.toString()}`;
+  const itemCountPropertyId = `itemCount${slot.toString()}`;
+
+  const itemType = getBlockDynamicProperty(loc, itemTypePropertyId) as
+    | string
+    | undefined;
+  if (itemType === undefined) {
+    return;
+  }
+
+  const itemCount = getBlockDynamicProperty(loc, itemCountPropertyId) as
+    | number
+    | undefined;
+  if (!itemCount) {
+    return;
+  }
+
+  return {
+    typeId: itemType,
+    count: itemCount,
+  };
+}
+
 export function setMachineSlotItem(
   loc: DimensionLocation,
   slot: number,
@@ -76,8 +95,8 @@ export function setMachineSlotItem(
   setChanged = true,
 ): void {
   const uid = getBlockUniqueId(loc);
-  const itemTypeObjective = getItemTypeScoreboardObjective(slot);
-  const itemCountObjective = getItemCountScoreboardObjective(slot);
+  const itemTypePropertyId = `itemType${slot.toString()}`;
+  const itemCountPropertyId = `itemCount${slot.toString()}`;
 
   if (setChanged) {
     const existingChangedItemSlotsArr = machineChangedItemSlots.get(uid);
@@ -89,23 +108,19 @@ export function setMachineSlotItem(
   }
 
   if (!newItemStack || newItemStack.count <= 0) {
-    itemTypeObjective.removeParticipant(uid);
-    itemCountObjective.removeParticipant(uid);
+    setBlockDynamicProperty(loc, itemTypePropertyId);
+    setBlockDynamicProperty(loc, itemCountPropertyId);
     return;
   }
 
-  itemTypeObjective.setScore(uid, newItemStack.typeIndex);
-  itemCountObjective.setScore(uid, newItemStack.count);
+  setBlockDynamicProperty(loc, itemTypePropertyId, newItemStack.typeId);
+  setBlockDynamicProperty(loc, itemCountPropertyId, newItemStack.count);
 }
 
 export function machineItemStackToItemStack(
-  element: UiItemSlotElementDefinition,
   machineItem?: MachineItemStack,
 ): ItemStack {
   return machineItem
-    ? new ItemStack(
-        element.allowedItems[machineItem.typeIndex],
-        machineItem.count,
-      )
+    ? new ItemStack(machineItem.typeId, machineItem.count)
     : new ItemStack("fluffyalien_energisticscore:ui_empty_slot");
 }

--- a/packs/BP/scripts/data_ipc.ts
+++ b/packs/BP/scripts/data_ipc.ts
@@ -1,0 +1,29 @@
+import {
+  GetMachineSlotPayload,
+  SetMachineSlotPayload,
+} from "@/public_api/src/machine_data_internal";
+import * as ipc from "mcbe-addon-ipc";
+import { getMachineSlotItem, setMachineSlotItem } from "./data";
+import { deserializeDimensionLocation } from "@/public_api/src/serialize_utils";
+import { MachineItemStack } from "@/public_api/src";
+
+export function getMachineSlotListener(
+  payload: ipc.SerializableValue,
+): MachineItemStack | null {
+  const data = payload as GetMachineSlotPayload;
+  return (
+    getMachineSlotItem(deserializeDimensionLocation(data.loc), data.slot) ??
+    null
+  );
+}
+
+export function setMachineSlotListener(payload: ipc.SerializableValue): null {
+  const data = payload as SetMachineSlotPayload;
+  setMachineSlotItem(
+    deserializeDimensionLocation(data.loc),
+    data.slot,
+    data.item,
+  );
+  return null;
+}
+

--- a/packs/BP/scripts/ipc_listeners.ts
+++ b/packs/BP/scripts/ipc_listeners.ts
@@ -1,9 +1,3 @@
-import { MachineItemStack } from "@/public_api/src";
-import { setMachineSlotItem } from "./data";
-import {
-  deserializeDimensionLocation,
-  SerializableDimensionLocation,
-} from "@/public_api/src/serialize_utils";
 import {
   NetworkLinkGetRequest,
   NetworkLinkGetResponse,
@@ -41,27 +35,15 @@ import {
   getItemMachineStorageHandler,
   setItemMachineStorageListener,
 } from "./item_machine_ipc";
-
-interface SetItemInMachineSlotPayload {
-  loc: SerializableDimensionLocation;
-  slot: number;
-  item?: MachineItemStack;
-}
+import { getMachineSlotListener, setMachineSlotListener } from "./data_ipc";
 
 registerListener(BecIpcListener.RegisterMachine, registerMachineListener);
 registerListener(
   BecIpcListener.RegisterStorageType,
   registerStorageTypeListener,
 );
-registerListener(BecIpcListener.SetMachineSlot, (payload_) => {
-  const payload = payload_ as SetItemInMachineSlotPayload;
-  setMachineSlotItem(
-    deserializeDimensionLocation(payload.loc),
-    payload.slot,
-    payload.item,
-  );
-  return null;
-});
+registerListener(BecIpcListener.SetMachineSlot, setMachineSlotListener);
+registerListener(BecIpcListener.GetMachineSlot, getMachineSlotListener);
 registerListener(BecIpcListener.DestroyNetwork, networkDestroyListener);
 registerListener(BecIpcListener.NetworkQueueSend, networkQueueSendListener);
 registerListener(BecIpcListener.Generate, generateListener);

--- a/packs/BP/scripts/machine.ts
+++ b/packs/BP/scripts/machine.ts
@@ -82,7 +82,7 @@ export function dropItemsStoredInMachine(
     const item = getMachineSlotItem(blockLocation, element.slotId);
     if (item) {
       blockLocation.dimension.spawnItem(
-        machineItemStackToItemStack(element, item),
+        machineItemStackToItemStack(item),
         Vector3Utils.add(blockLocation, { x: 0.5, y: 0.5, z: 0.5 }),
       );
     }

--- a/packs/BP/scripts/ui.ts
+++ b/packs/BP/scripts/ui.ts
@@ -184,10 +184,7 @@ function handleItemSlot(
   init: boolean,
 ): void {
   const expectedMachineItem = getMachineSlotItem(loc, element.slotId);
-  const expectedItemStack = machineItemStackToItemStack(
-    element,
-    expectedMachineItem,
-  );
+  const expectedItemStack = machineItemStackToItemStack(expectedMachineItem);
 
   const changedSlots = machineChangedItemSlots.get(getBlockUniqueId(loc));
   const slotChanged = changedSlots?.includes(element.slotId);
@@ -202,7 +199,7 @@ function handleItemSlot(
   if (!containerSlot.hasItem()) {
     clearUiItemsFromPlayer(player);
     setMachineSlotItem(loc, element.slotId, undefined, false);
-    containerSlot.setItem(machineItemStackToItemStack(element));
+    containerSlot.setItem(machineItemStackToItemStack());
     return;
   }
 
@@ -215,7 +212,7 @@ function handleItemSlot(
         loc,
         element.slotId,
         {
-          typeIndex: expectedMachineItem.typeIndex,
+          typeId: expectedMachineItem.typeId,
           count: containerSlot.amount,
         },
         false,
@@ -227,15 +224,16 @@ function handleItemSlot(
 
   clearUiItemsFromPlayer(player);
 
-  const newTypeIndex = element.allowedItems.indexOf(containerSlot.typeId);
+  const isAllowed =
+    element.allowedItems?.includes(containerSlot.typeId) ?? true;
   if (
-    newTypeIndex === -1 ||
+    !isAllowed ||
     // ensure the item has no special properties
     !containerSlot.isStackableWith(new ItemStack(containerSlot.typeId))
   ) {
     setMachineSlotItem(loc, element.slotId, undefined, false);
     player.dimension.spawnItem(containerSlot.getItem()!, player.location);
-    containerSlot.setItem(machineItemStackToItemStack(element));
+    containerSlot.setItem(machineItemStackToItemStack());
     return;
   }
 
@@ -243,7 +241,7 @@ function handleItemSlot(
     loc,
     element.slotId,
     {
-      typeIndex: newTypeIndex,
+      typeId: containerSlot.typeId,
       count: containerSlot.amount,
     },
     false,

--- a/packs/BP/scripts/utils/dynamic_property.ts
+++ b/packs/BP/scripts/utils/dynamic_property.ts
@@ -1,0 +1,47 @@
+import { getBlockUniqueId } from "@/public_api/src/machine_data_internal";
+import { DimensionLocation, Vector3, world } from "@minecraft/server";
+
+export type DynamicPropertyValue = boolean | number | string | Vector3;
+
+function makeBlockBaseDynamicPropertyId(loc: DimensionLocation): string {
+  return "_bdp" + getBlockUniqueId(loc);
+}
+
+export function getBlockDynamicProperty(
+  loc: DimensionLocation,
+  id: string,
+): DynamicPropertyValue | undefined {
+  return world.getDynamicProperty(makeBlockBaseDynamicPropertyId(loc) + id);
+}
+
+export function setBlockDynamicProperty(
+  loc: DimensionLocation,
+  id: string,
+  value?: DynamicPropertyValue,
+): void {
+  world.setDynamicProperty(makeBlockBaseDynamicPropertyId(loc) + id, value);
+}
+
+export function getBlockDynamicProperties(loc: DimensionLocation): string[] {
+  const blockBaseId = makeBlockBaseDynamicPropertyId(loc);
+
+  return world
+    .getDynamicPropertyIds()
+    .filter((id) => id.startsWith(blockBaseId))
+    .map((id) => id.slice(blockBaseId.length));
+}
+
+export function removeAllDynamicPropertiesForBlock(
+  loc: DimensionLocation,
+): void {
+  const blockBaseId = makeBlockBaseDynamicPropertyId(loc);
+
+  const properties = world
+    .getDynamicPropertyIds()
+    .filter((id) => id.startsWith(blockBaseId));
+
+  for (const property of properties) {
+    world.setDynamicProperty(property);
+  }
+}
+

--- a/public_api/src/bec_ipc_listener.ts
+++ b/public_api/src/bec_ipc_listener.ts
@@ -6,6 +6,7 @@ export enum BecIpcListener {
   RegisterStorageType = "fluffyalien_energisticscore:ipc.registerStorageType",
   RegisterItemMachine = "fluffyalien_energisticscore:ipc.registerItemMachine",
   SetMachineSlot = "fluffyalien_energisticscore:ipc.setMachineSlot",
+  GetMachineSlot = "fluffyalien_energisticscore:ipc.getMachineSlot",
   DestroyNetwork = "fluffyalien_energisticscore:ipc.destroyNetwork",
   NetworkQueueSend = "fluffyalien_energisticscore:ipc.networkQueueSend",
   Generate = "fluffyalien_energisticscore:ipc.generate",

--- a/public_api/src/machine_data_internal.ts
+++ b/public_api/src/machine_data_internal.ts
@@ -3,6 +3,23 @@ import {
   ScoreboardObjective,
   world,
 } from "@minecraft/server";
+import { SerializableDimensionLocation } from "./serialize_utils.js";
+import { MachineItemStack } from "./machine_data.js";
+
+/**
+ * @internal
+ */
+export interface GetMachineSlotPayload {
+  loc: SerializableDimensionLocation;
+  slot: number;
+}
+
+/**
+ * @internal
+ */
+export interface SetMachineSlotPayload extends GetMachineSlotPayload {
+  item?: MachineItemStack;
+}
 
 /**
  * @internal
@@ -24,26 +41,6 @@ export function getStorageScoreboardObjective(
 ): ScoreboardObjective | undefined {
   const id = `fluffyalien_energisticscore:storage${type}`;
   return world.scoreboard.getObjective(id);
-}
-
-/**
- * @internal
- */
-export function getItemTypeScoreboardObjective(
-  slot: number,
-): ScoreboardObjective {
-  const id = `fluffyalien_energisticscore:itemtype${slot.toString()}`;
-  return world.scoreboard.getObjective(id) ?? world.scoreboard.addObjective(id);
-}
-
-/**
- * @internal
- */
-export function getItemCountScoreboardObjective(
-  slot: number,
-): ScoreboardObjective {
-  const id = `fluffyalien_energisticscore:itemcount${slot.toString()}`;
-  return world.scoreboard.getObjective(id) ?? world.scoreboard.addObjective(id);
 }
 
 /**

--- a/public_api/src/machine_registry_types.ts
+++ b/public_api/src/machine_registry_types.ts
@@ -53,7 +53,11 @@ export interface UiItemSlotElementDefinition {
   type: "itemSlot";
   index: number;
   slotId: number;
-  allowedItems: string[];
+  /**
+   * Only allow specific items in this slot.
+   * @beta
+   */
+  allowedItems?: string[];
 }
 
 /**


### PR DESCRIPTION
Changes the machine inventory APIs to use dynamic properties instead of scoreboards. This makes `allowedItems` no longer required.

This PR closes #95