### PR TITLE
fix: network links now check io compatibility

### DIFF
--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -463,14 +463,9 @@ export class MachineNetwork extends DestroyableObject {
 
       if (!netLink) return;
 
-      const selfIo = IoCapabilities.fromMachine(
-        block,
-        "network_link",
-      );
+      const selfIo = IoCapabilities.fromMachine(block, "network_link");
 
-      const selfIsConduit = block.hasTag(
-        "fluffyalien_energisticscore:conduit",
-      );
+      const selfIsConduit = block.hasTag("fluffyalien_energisticscore:conduit");
 
       const linkedPositions = netLink.getConnections();
 
@@ -480,14 +475,15 @@ export class MachineNetwork extends DestroyableObject {
         if (
           linkedBlock === undefined ||
           visitedLocations.has(Vector3Utils.toString(linkedBlock.location))
-        ) continue;
-        
+        )
+          continue;
+
         const linkedIsConduit = linkedBlock.hasTag(
           "fluffyalien_energisticscore:conduit",
         );
-        
+
         if (!selfIo.acceptsType(ioType, linkedIsConduit)) continue;
-        
+
         const linkedIO = IoCapabilities.fromMachine(
           linkedBlock,
           "network_link",

--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -460,17 +460,41 @@ export class MachineNetwork extends DestroyableObject {
         block.dimension,
         block.location,
       );
+
       if (!netLink) return;
+
+      const selfIo = IoCapabilities.fromMachine(
+        block,
+        "network_link",
+      );
+
+      const selfIsConduit = block.hasTag(
+        "fluffyalien_energisticscore:conduit",
+      );
 
       const linkedPositions = netLink.getConnections();
 
       for (const pos of linkedPositions) {
         const linkedBlock = block.dimension.getBlock(pos);
+
         if (
           linkedBlock === undefined ||
           visitedLocations.has(Vector3Utils.toString(linkedBlock.location))
-        )
-          continue;
+        ) continue;
+        
+        const linkedIsConduit = linkedBlock.hasTag(
+          "fluffyalien_energisticscore:conduit",
+        );
+        
+        if (!selfIo.acceptsType(ioType, linkedIsConduit)) continue;
+        
+        const linkedIO = IoCapabilities.fromMachine(
+          linkedBlock,
+          "network_link",
+        );
+
+        if (!linkedIO.acceptsType(ioType, selfIsConduit)) continue;
+
         handleBlock(linkedBlock);
       }
     }
@@ -541,6 +565,7 @@ export class MachineNetwork extends DestroyableObject {
       next(block, "down");
     }
 
+    console.log(ioType.id, ioType.category, JSON.stringify(connections));
     return connections;
   }
 

--- a/packs/BP/scripts/network.ts
+++ b/packs/BP/scripts/network.ts
@@ -565,7 +565,6 @@ export class MachineNetwork extends DestroyableObject {
       next(block, "down");
     }
 
-    console.log(ioType.id, ioType.category, JSON.stringify(connections));
     return connections;
   }
 

--- a/public_api/src/io.ts
+++ b/public_api/src/io.ts
@@ -216,8 +216,8 @@ export class IoCapabilities {
     const strDirection = side.toLowerCase();
     const isSideDirection = side !== Direction.Up && side !== Direction.Down && side !== "network_link";
 
-    // "fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side}"
-    // "fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side}"
+    // "fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side|network_link}"
+    // "fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side|network_link}"
 
     const tagMatchesSide = (tag: string): boolean =>
       (isSideDirection && tag.endsWith(".side")) ||

--- a/public_api/src/io.ts
+++ b/public_api/src/io.ts
@@ -171,10 +171,10 @@ export class IoCapabilities {
    * Get the input/output capabilities of a machine.
    * @beta
    * @param machine The machine.
-   * @param side The side of the machine to check.
+   * @param side The side of the machine to check or "network_link" for linked connections
    * @returns A IoCapabilities object.
    */
-  static fromMachine(machine: Block, side: Direction): IoCapabilities {
+  static fromMachine(machine: Block, side: Direction | "network_link"): IoCapabilities {
     const tags = machine.getTags();
     const onlyAllowsConduitConnections = tags.includes(
       IO_REQUIRE_CONDUIT_CONNECTIONS_TAG,
@@ -210,11 +210,11 @@ export class IoCapabilities {
 
   private static fromMachineWithExplicitSides(
     tags: string[],
-    side: Direction,
+    side: Direction | "network_link",
     onlyAllowsConduitConnections: boolean,
   ): IoCapabilities {
     const strDirection = side.toLowerCase();
-    const isSideDirection = side !== Direction.Up && side !== Direction.Down;
+    const isSideDirection = side !== Direction.Up && side !== Direction.Down && side !== "network_link";
 
     // "fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side}"
     // "fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side}"

--- a/public_api/src/io.ts
+++ b/public_api/src/io.ts
@@ -174,7 +174,10 @@ export class IoCapabilities {
    * @param side The side of the machine to check or "network_link" for linked connections
    * @returns A IoCapabilities object.
    */
-  static fromMachine(machine: Block, side: Direction | "network_link"): IoCapabilities {
+  static fromMachine(
+    machine: Block,
+    side: Direction | "network_link",
+  ): IoCapabilities {
     const tags = machine.getTags();
     const onlyAllowsConduitConnections = tags.includes(
       IO_REQUIRE_CONDUIT_CONNECTIONS_TAG,
@@ -214,7 +217,10 @@ export class IoCapabilities {
     onlyAllowsConduitConnections: boolean,
   ): IoCapabilities {
     const strDirection = side.toLowerCase();
-    const isSideDirection = side !== Direction.Up && side !== Direction.Down && side !== "network_link";
+    const isSideDirection =
+      side !== Direction.Up &&
+      side !== Direction.Down &&
+      side !== "network_link";
 
     // "fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side|network_link}"
     // "fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side|network_link}"


### PR DESCRIPTION
Previously network links would not verify that the connected blocks were io compatible, that resolves this issue.

As a side effect of the implementation you can now also use "network_link" as an explicit side:
```
"fluffyalien_energisticscore:io.{type|category}.<StorageTypeId>.{north|east|south|west|up|down|side|network_link}"
"fluffyalien_energisticscore:io.any.{north|east|south|west|up|down|side|network_link}"
```