### PR TITLE
Add queueSend minimum priority option to fix batteries/storage type containers

### DIFF
--- a/packs/BP/scripts/machine_registry.ts
+++ b/packs/BP/scripts/machine_registry.ts
@@ -51,7 +51,7 @@ export class InternalRegisteredMachine extends RegisteredMachine {
     ) as Promise<MachineUpdateUiHandlerResponse>;
   }
 
-  invokeRecieveHandler(
+  invokeReceiveHandler(
     blockLocation: DimensionLocation,
     recieveType: string,
     recieveAmount: number,

--- a/packs/BP/scripts/network_ipc.ts
+++ b/packs/BP/scripts/network_ipc.ts
@@ -30,7 +30,12 @@ export function networkQueueSendListener(payload: ipc.SerializableValue): null {
   const block = location.dimension.getBlock(location);
   if (!block) return null;
 
-  MachineNetwork.getFromId(networkId)?.queueSend(block, type, amount);
+  MachineNetwork.getFromId(networkId)?.queueSend(
+    block,
+    type,
+    amount,
+    data.minPriority,
+  );
 
   return null;
 }
@@ -125,6 +130,7 @@ export function generateListener(payload: ipc.SerializableValue): null {
     block,
     type,
     fullAmount,
+    data.minPriority,
   );
 
   return null;

--- a/public_api/src/network.ts
+++ b/public_api/src/network.ts
@@ -84,18 +84,21 @@ export class MachineNetwork {
    * @param blockLocation The location of the machine that is sending the storage type.
    * @param type The storage type to send.
    * @param amount The amount to send. Must be greater than zero.
+   * @param minPriority The minimum machine priority to send to. Set to `null` to send to all priorities. Defaults to `null`.
    * @see {@link generate}
    */
   queueSend(
     blockLocation: DimensionLocation,
     type: string,
     amount: number,
+    minPriority: number | null = null,
   ): void {
     const payload: NetworkQueueSendPayload = {
       networkId: this.id,
       loc: makeSerializableDimensionLocation(blockLocation),
       type,
       amount,
+      minPriority,
     };
 
     ipcSend(BecIpcListener.NetworkQueueSend, payload);

--- a/public_api/src/network_internal.ts
+++ b/public_api/src/network_internal.ts
@@ -15,6 +15,7 @@ export interface NetworkQueueSendPayload extends NetworkInstanceMethodPayload {
   loc: SerializableDimensionLocation;
   type: string;
   amount: number;
+  minPriority: number | null;
 }
 
 /**
@@ -56,4 +57,5 @@ export interface GeneratePayload {
   loc: SerializableDimensionLocation;
   type: string;
   amount: number;
+  minPriority: number | null;
 }

--- a/public_api/src/network_utils.ts
+++ b/public_api/src/network_utils.ts
@@ -38,17 +38,20 @@ export function getBlockNetworkConnectionType(
  * @param blockLocation The location of the machine that is generating.
  * @param type The storage type to generate.
  * @param amount The amount to generate.
+ * @param minPriority The minimum machine priority to send to. Set to `null` to send to all priorities. Defaults to `null`.
  * @see {@link MachineNetwork.queueSend}
  */
 export function generate(
   blockLocation: DimensionLocation,
   type: string,
   amount: number,
+  minPriority: number | null = null,
 ): void {
   const payload: GeneratePayload = {
     loc: makeSerializableDimensionLocation(blockLocation),
     type,
     amount,
+    minPriority,
   };
 
   ipcSend(BecIpcListener.Generate, payload);


### PR DESCRIPTION
- added a minimum priority option to `queueSend` and `generate` to fix the issue where batteries would repeatedly send energy back and forth to each other
- api: added `minPriority?: number|null` argument to `generate`
- api: added `minPriority?: number|null` argument to `MachineNetwork#queueSend`